### PR TITLE
Introduce print command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,19 @@ plugins=(bol)
 
 This plugin comes with a CLI to perform simple tasks.
 
+If no subcommand is passed, it calls the `print` subcommand.
+
 #### 🆘 Help
 
 Each subcommand comes with its own `help` subcommand. That defines the usage and options with examples.
+
+#### 🖨 Print
+
+Print a random quote.
+
+```bash
+Usage: bol print [options]
+```
 
 #### ➕ Add a quote
 

--- a/bol.plugin.zsh
+++ b/bol.plugin.zsh
@@ -6,11 +6,11 @@ if [[ -o interactive ]] && [[ -o login ]]; then
 
     __BOL_QUOTES_PATH="${__BOL_SCRIPT_PATH}/quotes"
 
-    [ -z $BOL_QUIET_MODE ] && cat $(ls -d ${__BOL_QUOTES_PATH}/**/*.txt | shuf -n 1) && echo ""
-
     for _bol_config_file in ${__BOL_SCRIPT_PATH}/lib/**/*.zsh; do
         source "$_bol_config_file"
     done
+
+    [ -z $BOL_QUIET_MODE ] && bol print
 
     unset _bol_config_file
 

--- a/lib/cli.zsh
+++ b/lib/cli.zsh
@@ -45,7 +45,10 @@ function _bol {
       _describe 'command' subcmds
       ;;
     print)
-      subcmds=('help:Usage information')
+      subcmds=(
+        'help:Usage information'
+        '--preceding-new-line:Print a new line before the quote.'
+      )
       _describe 'command' subcmds
       ;;
     esac

--- a/lib/cli.zsh
+++ b/lib/cli.zsh
@@ -6,8 +6,8 @@
 
 function bol {
   if [[ $# -eq 0 ]]; then
-    _bol::help
-    return 1
+    _bol::print --preceding-new-line
+    return 0
   fi
 
   local command="$1"
@@ -33,6 +33,7 @@ function _bol {
   cmds=(
     'help:Usage information'
     'add:Add a quote'
+    'print:Print a random quote'
   )
 
   if ((CURRENT == 2)); then
@@ -40,6 +41,10 @@ function _bol {
   elif ((CURRENT == 3)); then
     case "$words[2]" in
     add)
+      subcmds=('help:Usage information')
+      _describe 'command' subcmds
+      ;;
+    print)
       subcmds=('help:Usage information')
       _describe 'command' subcmds
       ;;
@@ -65,7 +70,50 @@ Available commands:
 
  help           Print this help message
  add            Add a quote
+ print          Print a random quote
 HELP
+}
+
+# =============================== COMMAND: bol print =============================== #
+
+function _bol::print::help {
+  cat <<HELP
+Usage: bol print
+
+Print a random quote.
+
+Available options:
+  --preceding-new-line    Print a new line before the quote.
+HELP
+}
+
+function _bol::print {
+  if [ -z $__BOL_QUOTES_PATH ]; then
+    echo "Quote path not configured." 1>&2
+    return 1
+  fi
+
+  if [[ $# -eq 1 ]] && [ $1 = "help" ]; then
+    _bol::print::help
+    return 0
+  fi
+
+  while test $# -gt 0; do
+    case "$1" in
+    --preceding-new-line)
+      local precede_with_new_line="true"
+      shift 1
+      ;;
+    *)
+      echo "Don't know how to handle parameters: $*"
+      return 1
+      ;;
+    esac
+  done
+
+  [ "${precede_with_new_line}" = "true" ] && echo ""
+  cat $(ls -d ${__BOL_QUOTES_PATH}/**/*.txt | shuf -n 1)
+  echo ""
 }
 
 # =============================== COMMAND: bol add =============================== #


### PR DESCRIPTION
## Why are the changes necessary?

To add the ability to print a quote at anytime, not only when new terminal is opened, we need a command.

This PR introduces a CLI command `print`. This will be used to print a random quote.

If `bol` CLI is not fed any subcommand, it will call the `print` subcommand.

## What does this pull request cover?

- Introduce `bol print` command
- Introduce `bol print help` command 

## Breaking changes

None.

